### PR TITLE
Finetuned material score

### DIFF
--- a/engine/constants.go
+++ b/engine/constants.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	VERSION_STRING string = "0.9"
+	VERSION_STRING string = "0.9.tunedMaterialScore"
 )
 
 type rank int8

--- a/engine/constants.go
+++ b/engine/constants.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	VERSION_STRING string = "0.9.tunedMaterialScore"
+	VERSION_STRING string = "0.10"
 )
 
 type rank int8

--- a/engine/score.go
+++ b/engine/score.go
@@ -15,8 +15,8 @@ const (
 
 const (
 	MaterialPawnScore   = 100
-	MaterialKnightScore = 300
-	MaterialBishopScore = 300
+	MaterialKnightScore = 320
+	MaterialBishopScore = 330
 	MaterialRookScore   = 500
 	MaterialQueenScore  = 900
 )


### PR DESCRIPTION
Tests in Arena against DoctorB 1.2.1
before:
```
-----------------Magog.0.9-----------------
Magog.0.9 - DoctorB : 3,5/14 2-9-3 (010000=0=001=0)  25%  -191
```

after:
```
-----------------Magog.0.9.finetunedMaterial-----------------
Magog.0.9.finetunedMaterial - DoctorB   : 5,0/14 3-7-4 (1000=0=1001=0=)  36%  -100
```

And tests against Magog 0.9

```
-----------------Magog.0.9.finetunedMaterial-----------------
Magog.0.9.finetunedMaterial - Magog.0.9 : 8,0/14 2-0-12 (1===========1=)  57%   +49
```
