### PR TITLE
Narrow window for full eval

### DIFF
--- a/engine/constants.go
+++ b/engine/constants.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	VERSION_STRING string = "0.10.pstNoMobility"
+	VERSION_STRING string = "0.10.pstLazyNarrow"
 )
 
 type rank int8

--- a/engine/score.go
+++ b/engine/score.go
@@ -29,7 +29,7 @@ const (
 )
 
 // controls width of window where full evaluation is done
-const fullEvalScoreMargin = MaterialKnightScore + 20
+const fullEvalScoreMargin = MaterialKnightScore
 
 func pieceToScore(p piece) int {
 	switch p {
@@ -54,12 +54,12 @@ func pieceToScore(p piece) int {
 // Returns fulll static evaluation score for Position pos. It's given relative to the currently playing
 // side (negamax score)
 func Evaluate(pos *Position, depth int, debug ...bool) int {
-	return LazyEvaluate(pos, depth, debug...)
+	return LazyEvaluate(pos, depth, MinusInfinityScore, InfinityScore, debug...)
 }
 
 // Returns static evaluation score for Position pos. It's given relative to the currently playingside (negamax score)
 // If the score is outsied <alpha-fullEvalScoreMargin, beta+fullEvalScoreMargin> window it skips costly part of evaluation.
-func LazyEvaluate(pos *Position, depth int, debug ...bool) int {
+func LazyEvaluate(pos *Position, depth int, alpha, beta int, debug ...bool) int {
 	evaluatedNodes++
 
 	if isCheckMate(pos) {
@@ -69,7 +69,27 @@ func LazyEvaluate(pos *Position, depth int, debug ...bool) int {
 	gamePhaseFactor := gamePhaseFactor(pos)
 	materialSquaresScore := pieceSquareScore(pos, gamePhaseFactor, debug...)
 
-	return materialSquaresScore
+	if materialSquaresScore > beta+fullEvalScoreMargin ||
+		materialSquaresScore < alpha-fullEvalScoreMargin {
+		return materialSquaresScore
+	}
+
+	// mobility
+	currentMobilityScore := pos.countMoves() * MobilityScoreFactor
+	if currentMobilityScore == 0 {
+		return DrawScore
+	}
+	pos.flags = pos.flags ^ FlagWhiteTurn
+	enemyMobilityScore := pos.countMoves() * MobilityScoreFactor
+	pos.flags = pos.flags ^ FlagWhiteTurn
+	mobilityScore := currentMobilityScore - enemyMobilityScore
+	if len(debug) > 0 {
+		fmt.Println("gamePhaseFactor:", gamePhaseFactor,
+			"materialSquaresScore: ", materialSquaresScore,
+			"mobilityScore: ", mobilityScore)
+	}
+	var score int = materialSquaresScore + mobilityScore
+	return score
 }
 
 // (endgame) 0.0 <-------------> 1.0 (opening/midgame)

--- a/engine/search.go
+++ b/engine/search.go
@@ -234,7 +234,7 @@ func updateBestLine(currBestLine *[]Move, betterSubline []Move, betterMove Move)
 func (search *Search) quiescence(aPosGen *Generator, alpha, beta, depth int,
 	currBestLine *[]Move, startTime time.Time) int {
 	bestSubline := search.bestLineAtDepth[depth+1]
-	score := LazyEvaluate(aPosGen.getTopPos(), depth)
+	score := LazyEvaluate(aPosGen.getTopPos(), depth, alpha, beta)
 
 	if evaluatedNodes%int64(currmoveLogInterval) == 0 {
 		currMoveNo := aPosGen.firstMoveIdx

--- a/notes.txt
+++ b/notes.txt
@@ -556,3 +556,11 @@ And few things become apparrent.
     b. winning material with some tactics proceeding to endgame and promoting a pawn
 2. However many of the draws that defender obtained were accomplished by infinite checkmate. So the new version that
 knows nothing about mobility cannot forsee these situations.
+
+14.06.2024 - 3
+Turns out that lazy evaluation with narrower window is even better!
+    -----------------Magog.0.10.pstLazyEvalNarrow-----------------
+    Magog.0.10.pstLazyEvalNarrow - Magog.0.10.pstNoMobility : 8,0/14 4-2-8 (0=11=10=1=====)  57%   +49
+
+You can see that 0.10.pstNoMobility really does not understand the importance of developing.
+Frequently not developing rooks for example.


### PR DESCRIPTION
Another upgrade:

```
-----------------Magog.0.10.pstLazyEvalNarrow-----------------
Magog.0.10.pstLazyEvalNarrow - Magog.0.10.pstNoMobility : 8,0/14 4-2-8 (0=11=10=1=====)  57%   +49
```