### PR TITLE
Consider time increment

### DIFF
--- a/engine/constants.go
+++ b/engine/constants.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	VERSION_STRING string = "0.11.addedTime3.1"
+	VERSION_STRING string = "0.11.addedTime4"
 )
 
 type rank int8

--- a/engine/constants.go
+++ b/engine/constants.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	VERSION_STRING string = "0.11.addedTime2"
+	VERSION_STRING string = "0.11.addedTime3.1"
 )
 
 type rank int8

--- a/engine/constants.go
+++ b/engine/constants.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	VERSION_STRING string = "0.11"
+	VERSION_STRING string = "0.11.addedTime2"
 )
 
 type rank int8

--- a/engine/search.go
+++ b/engine/search.go
@@ -110,7 +110,6 @@ func (search *Search) alphaBeta(aPosGen *Generator, targetDepth, depth, alpha, b
 	currBestLine *[]Move, candidateLine *Line, startTime, endTime time.Time) int {
 	bestSubline := search.bestLineAtDepth[depth+1]
 	if targetDepth == depth {
-		// Evaluate(posGen.pos, depth)
 		return search.quiescence(aPosGen, alpha, beta, depth, currBestLine, startTime, endTime)
 	}
 
@@ -132,10 +131,6 @@ func (search *Search) alphaBeta(aPosGen *Generator, targetDepth, depth, alpha, b
 			candidateLine, startTime, endTime)
 		aPosGen.PopMove()
 
-		if search.interrupted || time.Now().After(endTime) {
-			break
-		}
-
 		if currScore >= beta {
 			return beta
 		}
@@ -143,7 +138,9 @@ func (search *Search) alphaBeta(aPosGen *Generator, targetDepth, depth, alpha, b
 			updateBestLine(currBestLine, bestSubline, move.mov)
 			alpha = currScore
 		}
-
+		if search.interrupted || time.Now().After(endTime) {
+			break
+		}
 		select {
 		case <-search.stop:
 			search.interrupted = true
@@ -178,16 +175,15 @@ func (search *Search) startAlphaBeta(aPosGen *Generator, targetDepth int, currBe
 			pvLine, starttime, endtime)
 		aPosGen.PopMove()
 
-		if search.interrupted || time.Now().After(endtime) {
-			break
-		}
-
 		if currScore > alpha {
 			updateBestLine(currBestLine, bestSubline, move.mov)
 			alpha = currScore
 
 			maybePrintNewPvInfo(alpha, targetDepth, search.getBestLine(), time.Duration(time.Since(starttime)), "")
 			// printInfo( alpha, targetDepth, search.getBestLine(), time.Duration(time.Since(starttime)), "in startAB:")
+		}
+		if search.interrupted || time.Now().After(endtime) {
+			break
 		}
 		if nextMoveWins(currScore) {
 			break

--- a/engine/search.go
+++ b/engine/search.go
@@ -39,7 +39,7 @@ func NewSearch() *Search {
 	return pv
 }
 
-func (search *Search) StartIterativeDeepening(endtime time.Time, maxDepth int) {
+func (search *Search) StartIterativeDeepening(startTime, endTime time.Time, maxDepth int) {
 	if ProfileFile != nil {
 		fmt.Println("starting profiling")
 
@@ -48,16 +48,15 @@ func (search *Search) StartIterativeDeepening(endtime time.Time, maxDepth int) {
 	}
 	var bestLine *Line = &Line{}
 	search.interrupted = false
-	startTime := time.Now()
 	evaluatedNodes = 0
 	var bestScore int
 	var depthCompleted int
 
 	for currDepth := 1; currDepth <= maxDepth; currDepth++ {
 		scoreAtDepth, oneLegalMove := search.startAlphaBeta(posGen, currDepth, &search.bestLineAtDepth[0],
-			bestLine, startTime, endtime)
+			bestLine, startTime, endTime)
 
-		if time.Now().After(endtime) {
+		if time.Now().After(endTime) {
 			break
 		}
 		if search.interrupted {

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -29,6 +29,9 @@ const (
 	uOptionValue string = "value"
 )
 
+// anti 'loose on time' duration in case of some random delays (printing on console, GC kicking in )
+const antiflagMillis int = 40
+
 var posGen *Generator
 var search *Search
 var Quit bool
@@ -183,10 +186,11 @@ func calcEndtime(blackMillisLeft, blackMillisIncrement, whiteMillisLeft, whiteMi
 	isBlackTurn := posGen.getTopPos().flags&FlagWhiteTurn == 0
 	var millisForMove int
 	if isBlackTurn {
-		millisForMove = blackMillisLeft / givenMovesToGo
+		millisForMove = blackMillisLeft/givenMovesToGo + blackMillisIncrement
 	} else {
-		millisForMove = whiteMillisLeft / givenMovesToGo
+		millisForMove = whiteMillisLeft/givenMovesToGo + whiteMillisIncrement
 	}
+	millisForMove -= antiflagMillis
 	now := time.Now()
 	endtime := now.Add(time.Millisecond * time.Duration(millisForMove))
 	return endtime

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -30,7 +30,7 @@ const (
 )
 
 // anti 'loose on time' duration in case of some random delays (printing on console, GC kicking in)
-const antiflagMillis int = 20
+const antiflagMillis int = 40
 
 var posGen *Generator
 var search *Search
@@ -183,16 +183,27 @@ out:
 	go search.StartIterativeDeepening(startTime, endtime, targetDepth)
 }
 
-func calcEndtime(startTime time.Time, blackMillisLeft, blackMillisIncrement, whiteMillisLeft, whiteMillisIncrement,
-	givenMovesToGo int) time.Time {
+func calcEndtime(startTime time.Time, blackMillisLeft, blackMillisInc, whiteMillisLeft, whiteMillisInc int,	
+	movesToGo int) time.Time {
 	isBlackTurn := posGen.getTopPos().flags&FlagWhiteTurn == 0
 	var millisForMove int
 	if isBlackTurn {
-		millisForMove = blackMillisLeft/givenMovesToGo + blackMillisIncrement
+		if blackMillisLeft > blackMillisInc {
+			millisForMove = blackMillisLeft/movesToGo + blackMillisInc
+		} else {
+			millisForMove = blackMillisLeft
+		}
 	} else {
-		millisForMove = whiteMillisLeft/givenMovesToGo + whiteMillisIncrement
+		if whiteMillisLeft > whiteMillisInc {
+			millisForMove = whiteMillisLeft/movesToGo + whiteMillisInc
+		} else {
+			millisForMove = whiteMillisLeft
+		}
 	}
 	millisForMove -= antiflagMillis
+	if millisForMove < 1 {
+		millisForMove = 1
+	}
 	endtime := startTime.Add(time.Millisecond * time.Duration(millisForMove))
 	return endtime
 }

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -29,8 +29,8 @@ const (
 	uOptionValue string = "value"
 )
 
-// anti 'loose on time' duration in case of some random delays (printing on console, GC kicking in)
-const antiflagMillis int = 40
+// anti 'loose on time' duration in case of delays (printing on console, GC kicking in, system clock granularity)
+const antiflagMillis int = 50
 
 var posGen *Generator
 var search *Search
@@ -227,9 +227,6 @@ func printInfo(score, depth int, bestLine []Move, timeElapsed time.Duration, deb
 }
 
 func printInfoAfterDepth(score, depth int, bestLine []Move, timeElapsed time.Duration, debugSuffix string) {
-	if depth < 2 {
-		return
-	}
 	line := Line{moves: bestLine}
 	fmt.Println("info depth", depth,
 		"score", formatScore(score),

--- a/notes.txt
+++ b/notes.txt
@@ -622,3 +622,12 @@ Timestamps on the left show that magog was 40 millis late.
     2024-06-15 14:07:34,837****Tour**Last game won by DoctorB with Black in 141 moves
 
 Also I commit basic openings that I use in tournaments for reference.
+
+16.06.2024
+More fixes in time management. Had to do it twice because at one point I've reintroduced bug
+fixed on 29.05.2024. Now it's good and playing stronger than ever!:
+
+    -----------------Magog.0.11.addedTime3-----------------
+    Magog.0.11.addedTime3 - DoctorB          : 5,0/14 2-6-6 (0==0=01===0001)  36%  -100
+    Magog.0.11.addedTime3 - EnkoChess_290818 : 1,5/14 1-12-1 (00000000010=00)  11%  -363
+    Magog.0.11.addedTime3 - Magog.0.9        : 10,0/14 7-1-6 (=1==1111==110=)  71%  +156

--- a/notes.txt
+++ b/notes.txt
@@ -631,3 +631,24 @@ fixed on 29.05.2024. Now it's good and playing stronger than ever!:
     Magog.0.11.addedTime3 - DoctorB          : 5,0/14 2-6-6 (0==0=01===0001)  36%  -100
     Magog.0.11.addedTime3 - EnkoChess_290818 : 1,5/14 1-12-1 (00000000010=00)  11%  -363
     Magog.0.11.addedTime3 - Magog.0.9        : 10,0/14 7-1-6 (=1==1111==110=)  71%  +156
+
+But arghh! It still lost on time (against Enko)!
+
+17.06.2024
+When it lost against enko another bug become apparent where magog would crash trying to return nil results (because it didn't find anything in ~1 ms).
+I've factored out the firs loop of iterative deepening so it will always complete and all the timeout checks are only
+done at later stages. 
+Another thing is that looks like Arena has a bug where it sometimes fails to increment wtime by winc. Or it attributes it to other player.
+Not sure exactly. But one thing certain is that in that game Enko was in time trouble (4 consecutive moves with btime=1ms) and then out of thin air it got +1000ms.
+These 5 moves by Enko played with the same tempo (~1015ms according to timestamps in arena.debug).
+OTOH magog was printing bestmove in ~50 ms (according to timestamps in arena.debug) but still got ~200ms less on successive moves until eventually it crashed.
+Will see it gets magical bonus if it does not crash.
+
+17.06.2024 - 2 
+Fixed the crash and looks like it can exploit the same time measuring quirk in Arena. This time it managed a 3-fold repetition because Enko couldn't mate it with pair
+of bishops. Also scores 1.5 point more against DrB than 0.9! By only improving time control.
+    -----------------Magog.0.11.addedTime4-----------------
+    Magog.0.11.addedTime4 - DoctorB          : 5,0/14 2-6-6 (0=00=01===0=01)  36%  -100
+    Magog.0.11.addedTime4 - EnkoChess_290818 : 2,0/14 1-11-2 (00000000010==0)  14%  -315
+    Magog.0.11.addedTime4 - Magog.0.9        : 10,0/14 7-1-6 (=1==1111==110=)  71%  +156
+

--- a/notes.txt
+++ b/notes.txt
@@ -577,7 +577,7 @@ old results for reference:
     Magog.0.9 - EnkoChess_290818  : 2,0/14 0-10-4 (000000=0=0==00)  14%  -315
 
 15.06.2024 - 2 
-Pit 0.11 vs 0.9. 
+I pit 0.11 against 0.9. 
     -----------------Magog.0.11-----------------
     Magog.0.11 - Magog.0.9        : 7,0/14 3-3-8 (=1==10====1=00)  50%    ±0
 
@@ -596,3 +596,29 @@ added time and always allocates time for next move by dividing time left by expe
 (by default 30). So now it's time left goes down asymptotically to 30s. At this point all the moves are garbage.
 If it could knew that it has more time then it could keep on playin decently in the crucial part of the game
 when positions are still around equal
+
+15.06.2024 - 3
+I pit 0.11.addedTime against others. Looks a little better I guess..
+    -----------------Magog.0.11.addedTime-----------------
+    Magog.0.11.addedTime - DoctorB          : 4,0/14 1-7-6 (=0=0=01===0000)  29%  -156
+    Magog.0.11.addedTime - EnkoChess_290818 : 1,0/14 1-13-0 (00000000010000)   7%  -449
+    Magog.0.11.addedTime - Magog.0.9        : 10,0/14 7-1-6 (1===1111==110=)  71%  +156
+
+It lost one game against DoctorB on time - I forgot to use antiflagDuration.. 
+But at least now the log gives me some idea how big should it be. Looks like it should be 10x bigger than initial guess of 4 ms.
+Timestamps on the left show that magog was 40 millis late.
+
+    2024-06-15 14:07:33,797-->2:go wtime 1 btime 52152 winc 1000 binc 1000
+    [...]
+    2024-06-15 14:07:34,715<--2:info currmove g4f5 currmovenumber 1 nodes 1000000 time 870 nps 1148920
+    2024-06-15 14:07:34,817<--2:info score cp 167 depth 7 nps 1139808 time 1009 nodes 1150405 pv g4f5 d4d6 h2h7 f8g8 h7c7 d6d5 f5e4 
+    2024-06-15 14:07:34,817-->2:stop
+    2024-06-15 14:07:34,837<--2:bestmove g4f5
+    2024-06-15 14:07:34,837*2*---------> Arena:Illegal move!: "bestmove g4f5" ()
+    2024-06-15 14:07:34,837<--2:fatal error: all goroutines are asleep - deadlock!
+    2024-06-15 14:07:34,837****Tour**Game end: 0-1 {0-1 White forfeits on time}
+    2024-06-15 14:07:34,837<--2:goroutine 1 [chan send]:
+    2024-06-15 14:07:34,837<--2:macsmol/magog/engine.ParseInputLine({0xc0003a06c4?, 0xc0000cc02b?})
+    2024-06-15 14:07:34,837****Tour**Last game won by DoctorB with Black in 141 moves
+
+Also I commit basic openings that I use in tournaments for reference.

--- a/testData/basic openings.pgn
+++ b/testData/basic openings.pgn
@@ -1,0 +1,20 @@
+[Event "1. Kings's Pawn Game"]
+1. e4 e5
+
+[Event "2. Queen's Pawn Game"]
+1.d4 
+
+[Event "3. English Opening"]
+1.c4 
+
+[Event "4. Zukertort Opening"]
+1.Nf3
+
+[Event "5. Scandinavian Defense"]
+1.e4 d5
+
+[Event "6. Sicilian Defense"]
+1.e4 c5
+
+[Event "7. Italian Game"]
+1. e4 e5 2. Nf3 Nc6 3. Bc4


### PR DESCRIPTION
Finaly version with no crashes on looses on time when playing with increment.

-----------------Magog.0.11.addedTime4-----------------
Magog.0.11.addedTime4 - DoctorB          : 5,0/14 2-6-6 (0=00=01===0=01)  36%  -100
Magog.0.11.addedTime4 - EnkoChess_290818 : 2,0/14 1-11-2 (00000000010==0)  14%  -315
Magog.0.11.addedTime4 - Magog.0.9        : 10,0/14 7-1-6 (=1==1111==110=)  71%  +156